### PR TITLE
CORE-157 Add support for ami 4. Switches from form post to json post.…

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('fog', '~> 1.25.0')
   s.add_dependency('fog-core', '~> 1.25.0')
 
-  s.add_development_dependency('rake', '~> 0.9')
+  s.add_development_dependency('rake', '~> 10.1.0')
   s.add_development_dependency('rspec', '~> 2.12.0')
   s.add_development_dependency('timecop', '~> 0.5')
   s.add_development_dependency('fakefs', '~> 0.4')

--- a/lib/elasticity.rb
+++ b/lib/elasticity.rb
@@ -26,6 +26,8 @@ require 'elasticity/hive_step'
 require 'elasticity/pig_step'
 require 'elasticity/streaming_step'
 
+require 'elasticity/version'
+
 module Elasticity
 
   class << self

--- a/lib/elasticity/emr.rb
+++ b/lib/elasticity/emr.rb
@@ -183,9 +183,13 @@ module Elasticity
       }.merge!(job_flow_config)
       aws_result = @aws_request.submit(params)
       yield aws_result if block_given?
-      xml_doc = Nokogiri::XML(aws_result)
-      xml_doc.remove_namespaces!
-      xml_doc.xpath('/RunJobFlowResponse/RunJobFlowResult/JobFlowId').text
+      if job_flow_config.key?(:release_label)
+        JSON.parse(aws_result)['JobFlowId']
+      else
+        xml_doc = Nokogiri::XML(aws_result)
+        xml_doc.remove_namespaces!
+        xml_doc.xpath('/RunJobFlowResponse/RunJobFlowResult/JobFlowId').text
+      end
     end
 
     # Enabled or disable "termination protection" on the specified job flows.

--- a/lib/elasticity/instance_group.rb
+++ b/lib/elasticity/instance_group.rb
@@ -8,6 +8,7 @@ module Elasticity
     attr_accessor :type
     attr_accessor :role
     attr_accessor :ebs
+    attr_accessor :bid_price
 
     attr_reader :bid_price
     attr_reader :market

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -157,7 +157,7 @@ module Elasticity
       preamble[:name] = @name unless @name.nil?
 
       major_version = @ami_version.split('.').first.to_i if @ami_version
-      if major_version && major_version > 3
+      if major_version && major_version >= 4
         preamble[:release_label] = "emr-#@ami_version"
         preamble.delete(:ami_version)
       else

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -155,7 +155,15 @@ module Elasticity
       preamble = @defaults
 
       preamble[:name] = @name unless @name.nil?
-      preamble[:ami_version] = @ami_version unless @ami_version.nil?
+
+      major_version = @ami_version.split('.').first.to_i if @ami_version
+      if major_version && major_version > 3
+        preamble[:release_label] = "emr-#@ami_version"
+        preamble.delete(:ami_version)
+      else
+        preamble[:ami_version] = @ami_version unless @ami_version.nil?
+      end
+
       preamble[:visible_to_all_users] = @visible_to_all_users unless @visible_to_all_users.nil?
 
       preamble[:instances] ||= {}

--- a/lib/elasticity/streaming_step.rb
+++ b/lib/elasticity/streaming_step.rb
@@ -26,7 +26,11 @@ module Elasticity
     end
 
     def to_aws_step(job_flow)
-      step = Elasticity::CustomJarStep.new('/home/hadoop/contrib/streaming/hadoop-streaming.jar')
+      if job_flow.ami_version.split('.').first.to_i >= 4
+        step = Elasticity::CustomJarStep.new('/usr/lib/hadoop-mapreduce/hadoop-streaming.jar')
+      else
+        step = Elasticity::CustomJarStep.new('/home/hadoop/contrib/streaming/hadoop-streaming.jar')
+      end
       step.name = @name
       step.action_on_failure = @action_on_failure
       step.arguments = @arguments + ['-input', @input_bucket, '-output', @output_bucket, '-mapper', @mapper, '-reducer', @reducer]

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.7.2'
+  VERSION = '2.8.0'
 end


### PR DESCRIPTION
… Implementation is

based on elasticity origin repo master branch. Expose bid_price of instance group. This
is used in the data-pipelines repo when creating the ruby hash that represents the json post request. There it converts the bid_price to a string since ami 4 requires the bid_price to be of type string.