### PR TITLE
VPC Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ jobflow.placement                         = 'us-east-1a'
 jobflow.instance_count                    = 2
 jobflow.master_instance_type              = 'm1.small'
 jobflow.slave_instance_type               = 'm1.small'
+jobflow.additional_master_security_groups = ['sg-1111', 'sg-2222']
+jobflow.additional_slave_security_groups  = ['sg-1111', 'sg-2222']
 ```
 
 ## 3 - Configure Instance Groups (optional)

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -177,7 +177,10 @@ module Elasticity
       preamble[:instances][:placement] = {:availability_zone => @placement} if @placement
 
       preamble[:placement] = {:availability_zone => @placement} if @placement
-      preamble[:instances].merge!(:ec2_subnet_id => @ec2_subnet_id) if @ec2_subnet_id
+      if @ec2_subnet_id
+        preamble[:instances].merge!(:ec2_subnet_id => @ec2_subnet_id)
+        preamble[:instances].delete(:placement)
+      end
 
       preamble
     end

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -23,6 +23,8 @@ module Elasticity
     attr_accessor :defaults
     attr_reader :access_key
     attr_reader :secret_key
+    attr_accessor :additional_master_security_groups
+    attr_accessor :additional_slave_security_groups
 
     def initialize(access=nil, secret=nil)
 
@@ -174,6 +176,9 @@ module Elasticity
       @ec2_key_name ||= preamble[:ec2_key_name]
 
       preamble[:instances].merge!(:ec2_key_name => @ec2_key_name) if @ec2_key_name
+      preamble[:instances].merge!(:additional_master_security_groups => @additional_master_security_groups) if @additional_master_security_groups
+      preamble[:instances].merge!(:additional_slave_security_groups => @additional_slave_security_groups) if @additional_slave_security_groups
+
       preamble[:instances][:placement] = {:availability_zone => @placement} if @placement
 
       preamble[:placement] = {:availability_zone => @placement} if @placement

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -172,11 +172,12 @@ module Elasticity
       preamble[:instances][:instance_groups] = jobflow_instance_groups
 
       @ec2_key_name ||= preamble[:ec2_key_name]
+
       preamble[:instances].merge!(:ec2_key_name => @ec2_key_name) if @ec2_key_name
       preamble[:instances][:placement] = {:availability_zone => @placement} if @placement
 
       preamble[:placement] = {:availability_zone => @placement} if @placement
-      preamble.merge!(:ec2_subnet_id => @ec2_subnet_id) if @ec2_subnet_id
+      preamble[:instances].merge!(:ec2_subnet_id => @ec2_subnet_id) if @ec2_subnet_id
 
       preamble
     end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.8.0'
+  VERSION = '2.8.1'
 end

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -381,7 +381,7 @@ describe Elasticity::JobFlow do
     context 'when a VPC subnet ID is specified' do
       it 'should include it in the preamble' do
         subject.ec2_subnet_id = 'subnet-118b9d79'
-        subject.send(:jobflow_preamble).should be_a_hash_including({:ec2_subnet_id => 'subnet-118b9d79'})
+        subject.send(:jobflow_preamble)[:instances].should be_a_hash_including({:ec2_subnet_id => 'subnet-118b9d79'})
       end
     end
 

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -19,6 +19,8 @@ describe Elasticity::JobFlow do
   its(:keep_job_flow_alive_when_no_steps) { should == false }
   its(:placement) { should == 'us-east-1a' }
   its(:visible_to_all_users) { should == false }
+  its(:additional_master_security_groups) { should == nil }
+  its(:additional_slave_security_groups) { should == nil }
 
   describe '.initialize' do
     it 'should set the access and secret keys to nil by default' do
@@ -397,6 +399,19 @@ describe Elasticity::JobFlow do
       end
     end
 
+    context 'when additional master security groups is provided' do
+      it 'should include it in the preamble' do
+        subject.additional_master_security_groups = ['group1', 'group2']
+        subject.send(:jobflow_preamble)[:instances].should be_a_hash_including({:additional_master_security_groups => ['group1', 'group2']})
+      end
+    end
+
+    context 'when additional slave security groups is provided' do
+      it 'should include it in the preamble' do
+        subject.additional_slave_security_groups = ['group1', 'group2']
+        subject.send(:jobflow_preamble)[:instances].should be_a_hash_including({:additional_slave_security_groups => ['group1', 'group2']})
+      end
+    end
   end
 
   describe '#run' do

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -379,9 +379,14 @@ describe Elasticity::JobFlow do
     end
 
     context 'when a VPC subnet ID is specified' do
-      it 'should include it in the preamble' do
+      before do
         subject.ec2_subnet_id = 'subnet-118b9d79'
+      end
+      it 'should include it in the preamble' do
         subject.send(:jobflow_preamble)[:instances].should be_a_hash_including({:ec2_subnet_id => 'subnet-118b9d79'})
+      end
+      it 'should not include the placement since a subnet implies a placement' do
+        subject.send(:jobflow_preamble)[:instances].should_not include(:placement)
       end
     end
 


### PR DESCRIPTION
Merging in 3 upstream changes (and modifying to work with our fork) to support subnets and additional security groups if set - ignores them otherwise, so this is safe to use even before any further changes. Bumps minor version
