### PR TITLE
WEB-1781: Upgrade rest-client version to fix known vulnerability

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Streamlined, programmatic access to Amazon's Elastic Map Reduce service.}
   s.description = %q{Streamlined, programmatic access to Amazon's Elastic Map Reduce service, driven by the Sharethrough team's requirements for belting out EMR jobs.}
 
-  s.add_dependency('rest-client', '~> 1.7.2')
+  s.add_dependency('rest-client', '~> 1.8.0')
   s.add_dependency('nokogiri', '~> 1.6.0')
   s.add_dependency('fog', '~> 1.25.0')
   s.add_dependency('fog-core', '~> 1.25.0')

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.8.1'
+  VERSION = '2.9.0'
 end


### PR DESCRIPTION
This is used in emr-jobs, which is used for attribution-jobs, which is used in webapp because we use a bit of functionality to deal with job settings there (we want to drop those dependencies from the Rails apps). 

It's probably a worthwhile change regardless, I'll bump emr-jobs in the data-pipelines PR

Changelog: https://github.com/rest-client/rest-client/blob/master/history.md