### PR TITLE
[APL-2001] Placed-Elasticity: Support Session Token

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -15,11 +15,13 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '~> 1.7.1')
   s.add_dependency('fog', '~> 1.25.0')
   s.add_dependency('fog-core', '~> 1.25.0')
+  s.add_dependency('aws-sdk-core', '~> 2.0')
 
   s.add_development_dependency('rake', '~> 10.1.0')
   s.add_development_dependency('rspec', '~> 2.12.0')
   s.add_development_dependency('timecop', '~> 0.5')
   s.add_development_dependency('fakefs', '~> 0.4')
+  s.add_development_dependency('xmlrpc', '~> 0.3.0')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")

--- a/lib/elasticity.rb
+++ b/lib/elasticity.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'set'
 require 'time'
 
+require 'aws-sdk-core'
 require 'rest_client'
 require 'nokogiri'
 require 'fog'

--- a/lib/elasticity/aws_request.rb
+++ b/lib/elasticity/aws_request.rb
@@ -52,14 +52,14 @@ module Elasticity
 
     def headers_to_sign
       headers = {
-        'Content-Type' => 'application/x-amz-json-1.1',
-        'Host' => host,
-        'User-Agent' => "elasticity/#{Elasticity::VERSION}",
-        'X-Amz-Date' => @timestamp.strftime('%Y%m%dT%H%M%SZ'),
-        'X-Amz-Target' => "ElasticMapReduce.#{@operation}",
+        'content-type' => 'application/x-amz-json-1.1',
+        'host' => host,
+        'user-agent' => "elasticity/#{Elasticity::VERSION}",
+        'x-amz-date' => @timestamp.strftime('%Y%m%dT%H%M%SZ'),
+        'x-amz-target' => "ElasticMapReduce.#{@operation}",
       }
       if !@session_token.nil?
-        headers['X-Amz-Security-Token'] = @session_token
+        headers['x-amz-security-token'] = @session_token
       end
       headers
     end

--- a/lib/elasticity/aws_request.rb
+++ b/lib/elasticity/aws_request.rb
@@ -9,6 +9,7 @@ module Elasticity
 
     attr_reader :access_key
     attr_reader :secret_key
+    attr_reader :session_token
     attr_reader :host
     attr_reader :protocol
 
@@ -18,6 +19,7 @@ module Elasticity
     def initialize(access=nil, secret=nil, options={})
       @access_key = get_access_key(access)
       @secret_key = get_secret_key(secret)
+      @session_token = get_session_token(options[:session_token])
       @region = {:region => 'us-east-1'}.merge(options)[:region]
       @host = "elasticmapreduce.#@region.amazonaws.com"
       @protocol = {:secure => true}.merge(options)[:secure] ? 'https' : 'http'
@@ -25,20 +27,18 @@ module Elasticity
     end
 
     def headers
-      headers = {
-        'Authorization' => "AWS4-HMAC-SHA256 Credential=#{@access_key}/#{credential_scope}, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-target, Signature=#{aws_v4_signature}",
-        'Content-Type' => 'application/x-amz-json-1.1',
-        'Host' => host,
-        'User-Agent' => "elasticity/#{Elasticity::VERSION}",
-        'X-Amz-Content-SHA256' => Digest::SHA256.hexdigest(payload),
-        'X-Amz-Date' => @timestamp.strftime('%Y%m%dT%H%M%SZ'),
-        'X-Amz-Target' => "ElasticMapReduce.#{@operation}",
-      }
-      headers
-    end
-
-    def url
-      "https://#{host}"
+      signer = Aws::Sigv4::Signer.new(
+        service: 'elasticmapreduce',
+        region: @region,
+        credentials: Aws::Credentials.new(@access_key, @secret_key, @session_token)
+      )
+      signature = signer.sign_request({
+        http_method: 'POST',
+        url: '/',
+        headers: headers_to_sign(),
+        body: payload
+      })
+      headers_to_sign().merge(signature.headers)
     end
 
     def payload
@@ -50,68 +50,28 @@ module Elasticity
       "elasticmapreduce.#{@region}.amazonaws.com"
     end
 
-    def credential_scope
-      "#{@timestamp.strftime('%Y%m%d')}/#{@region}/#{SERVICE_NAME}/aws4_request"
-    end
-
-    # Task 1: Create a Canonical Request For Signature Version 4
-    #   http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-    def canonical_request
-      [
-        'POST',
-        '/',
-        '',
-        'content-type:application/x-amz-json-1.1',
-        "host:#{host}",
-        "user-agent:elasticity/#{Elasticity::VERSION}",
-        "x-amz-content-sha256:#{Digest::SHA256.hexdigest(payload)}",
-        "x-amz-date:#{@timestamp.strftime('%Y%m%dT%H%M%SZ')}",
-        "x-amz-target:ElasticMapReduce.#{@operation}",
-        '',
-        'content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-target',
-        Digest::SHA256.hexdigest(payload)
-      ].join("\n")
-    end
-
-    # Task 2: Create a String to Sign for Signature Version 4
-    #   http://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
-    def string_to_sign
-      [
-        'AWS4-HMAC-SHA256',
-        @timestamp.strftime('%Y%m%dT%H%M%SZ'),
-        credential_scope,
-        Digest::SHA256.hexdigest(canonical_request)
-      ].join("\n")
-    end
-
-    # Task 3: Calculate the AWS Signature Version 4
-    #   http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
-    def aws_v4_signature
-      date = OpenSSL::HMAC.digest('sha256', 'AWS4' + @secret_key, @timestamp.strftime('%Y%m%d'))
-      region = OpenSSL::HMAC.digest('sha256', date, @region)
-      service = OpenSSL::HMAC.digest('sha256', region, SERVICE_NAME)
-      signing_key = OpenSSL::HMAC.digest('sha256', service, 'aws4_request')
-
-      OpenSSL::HMAC.hexdigest('sha256', signing_key, string_to_sign)
+    def headers_to_sign
+      headers = {
+        'Content-Type' => 'application/x-amz-json-1.1',
+        'Host' => host,
+        'User-Agent' => "elasticity/#{Elasticity::VERSION}",
+        'X-Amz-Date' => @timestamp.strftime('%Y%m%dT%H%M%SZ'),
+        'X-Amz-Target' => "ElasticMapReduce.#{@operation}",
+      }
+      if !@session_token.nil?
+        headers['X-Amz-Security-Token'] = @session_token
+      end
+      headers
     end
 
     def submit(ruby_params)
-      if ruby_params.key?(:release_label)
-        @ruby_service_hash = ruby_params
-        @operation = ruby_params[:operation]
-      else
-        aws_params = AwsRequest.convert_ruby_to_aws(ruby_params)
-        signed_params = sign_params(aws_params)
-      end
-
+      @operation = ruby_params[:operation]
+      @ruby_service_hash = ruby_params
       begin
-        if ruby_params.key?(:release_label)
-          RestClient.post("#@protocol://#@host", payload, headers)
-        else
-          RestClient.post("#@protocol://#@host", signed_params, :content_type => 'application/x-www-form-urlencoded; charset=utf-8')
-        end
+        RestClient.post("#@protocol://#@host", payload, headers)
       rescue RestClient::BadRequest => e
-        raise ArgumentError, "AWS parsed error response: #{AwsRequest.parse_error_response(e.http_body)}\n\nAWS raw http response: #{e.http_body}\n\nParams:#{ruby_params}"
+        raise ArgumentError, "AWS parsed error response: #{AwsRequest.parse_error_response(e.http_body)}\n\n" +
+                             "AWS raw http response: #{e.http_body}\n\nParams:#{ruby_params}"
       end
     end
 
@@ -138,30 +98,10 @@ module Elasticity
       raise MissingKeyError, 'Please provide a secret key or set AWS_SECRET_ACCESS_KEY.'
     end
 
-    # (Used from RightScale's right_aws gem.)
-    # EC2, SQS, SDB and EMR requests must be signed by this guy.
-    # See: http://docs.amazonwebservices.com/AmazonSimpleDB/2007-11-07/DeveloperGuide/index.html?REST_RESTAuth.html
-    #      http://developer.amazonwebservices.com/connect/entry.jspa?externalID=1928
-    def sign_params(service_hash)
-      service_hash.merge!({
-        'AWSAccessKeyId' => @access_key,
-        'Timestamp' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S.000Z'),
-        'SignatureVersion' => '2',
-        'SignatureMethod' => 'HmacSHA256'
-      })
-      canonical_string = service_hash.keys.sort.map do |key|
-        "#{AwsRequest.aws_escape(key)}=#{AwsRequest.aws_escape(service_hash[key])}"
-      end.join('&')
-      string_to_sign = "POST\n#{@host.downcase}\n/\n#{canonical_string}"
-      signature = AwsRequest.aws_escape(Base64.encode64(OpenSSL::HMAC.digest("sha256", @secret_key, string_to_sign)).strip)
-      "#{canonical_string}&Signature=#{signature}"
-    end
-
-    # (Used from RightScale's right_aws gem)
-    # Escape a string according to Amazon's rules.
-    # See: http://docs.amazonwebservices.com/AmazonSimpleDB/2007-11-07/DeveloperGuide/index.html?REST_RESTAuth.html
-    def self.aws_escape(param)
-      ERB::Util.url_encode(param)
+    def get_session_token(session_token)
+      return session_token if session_token
+      return ENV['AWS_SESSION_TOKEN'] if ENV['AWS_SESSION_TOKEN']
+      return nil # Session token is optional, and is nil unless working with temporary role IAM credentials.
     end
 
     # Since we use the same structure as AWS, we can generate AWS param names

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -25,10 +25,11 @@ module Elasticity
     attr_accessor :defaults
     attr_reader :access_key
     attr_reader :secret_key
+    attr_reader :session_token
     attr_accessor :additional_master_security_groups
     attr_accessor :additional_slave_security_groups
 
-    def initialize(access=nil, secret=nil)
+    def initialize(access=nil, secret=nil, session_token=nil)
 
       @access_key = access
       @secret_key = secret
@@ -45,12 +46,14 @@ module Elasticity
 
       @access_key = access
       @secret_key = secret
+      @session_token = session_token
     end
 
-    def self.from_jobflow_id(access, secret, jobflow_id, region = 'us-east-1')
-      JobFlow.new(access, secret).tap do |j|
+    def self.from_jobflow_id(access, secret, jobflow_id, region = 'us-east-1', options = {})
+      JobFlow.new(access, secret, session_token).tap do |j|
         j.instance_variable_set(:@region, region)
         j.instance_variable_set(:@jobflow_id, jobflow_id)
+        j.instance_variable_set(:@session_token, options[:session_token])
       end
     end
 
@@ -166,7 +169,7 @@ module Elasticity
 
     def emr
       @region ||= (@placement && @placement.match(/(\w+-\w+-\d+)/)[0]) || 'us-east-1'
-      @emr ||= Elasticity::EMR.new(@access_key, @secret_key, :region => @region)
+      @emr ||= Elasticity::EMR.new(@access_key, @secret_key, :region => @region, :session_token => @session_token)
     end
 
     def is_jobflow_running?

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.9.7'
+  VERSION = '2.10.0'
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.9.6'
+  VERSION = '2.9.7'
 end

--- a/spec/lib/elasticity/aws_request_spec.rb
+++ b/spec/lib/elasticity/aws_request_spec.rb
@@ -25,27 +25,31 @@ describe Elasticity::AwsRequest do
 
       context 'when the proper environment variables are set' do
 
-        context 'when access and secret key are not provided' do
+        context 'when access key, secret key, and session token are not provided' do
           let(:default_values) { Elasticity::AwsRequest.new }
           before do
             ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('ENV_ACCESS')
             ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('ENV_SECRET')
+            ENV.stub(:[]).with('AWS_SESSION_TOKEN').and_return('ENV_SESSION')
           end
           it 'should set access and secret keys' do
             default_values.access_key.should == 'ENV_ACCESS'
             default_values.secret_key.should == 'ENV_SECRET'
+            default_values.session_token.should == 'ENV_SESSION'
           end
         end
 
-        context 'when access and secret key are nil' do
+        context 'when access key, secret key, and session token are nil' do
           let(:nil_values) { Elasticity::AwsRequest.new(nil, nil) }
           before do
             ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('ENV_ACCESS')
             ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('ENV_SECRET')
+            ENV.stub(:[]).with('AWS_SESSION_TOKEN').and_return('ENV_SESSION')
           end
           it 'should set access and secret keys' do
             nil_values.access_key.should == 'ENV_ACCESS'
             nil_values.secret_key.should == 'ENV_SECRET'
+            nil_values.session_token.should == 'ENV_SESSION'
           end
         end
 
@@ -127,13 +131,6 @@ describe Elasticity::AwsRequest do
 
   end
 
-  describe '#sign_params' do
-    it 'should sign according to AWS rules' do
-      signed_params = subject.send(:sign_params, {})
-      signed_params.should == 'AWSAccessKeyId=access&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2011-04-10T18%3A44%3A56.000Z&Signature=t%2BccC38VxCKyk2ROTKo9vnECsntKoU0RBAFklHWP5bE%3D'
-    end
-  end
-
   describe '#submit' do
 
     let(:request) do
@@ -145,10 +142,10 @@ describe Elasticity::AwsRequest do
 
     it 'should POST a properly assembled request' do
       ruby_params = {}
-      aws_params = {}
       Elasticity::AwsRequest.should_receive(:convert_ruby_to_aws).with(ruby_params).and_return(ruby_params)
-      request.should_receive(:sign_params).with(aws_params).and_return('SIGNED_PARAMS')
-      RestClient.should_receive(:post).with('PROTOCOL://HOSTNAME', 'SIGNED_PARAMS', :content_type => 'application/x-www-form-urlencoded; charset=utf-8')
+      request.should_receive(:headers).and_return('HEADERS')
+      request.should_receive(:payload).and_return('PAYLOAD')
+      RestClient.should_receive(:post).with('PROTOCOL://HOSTNAME', 'PAYLOAD', 'HEADERS')
       request.submit(ruby_params)
     end
 


### PR DESCRIPTION
Changes:
- Add support for using temporary role credentials, which requires passing a session token in addition to access key and secret key.
- Use `Aws::Sigv4::Signer` to sign requests, and remove code that was doing it manually.
- Remove legacy Sigv2 signing code path.

Testing:
- Tested E2E locally w/ example pipeline
  - with temporary role creds
  - with (standard) user creds
  - tested lesser-used code paths which perform EMR API calls, such as `terminate_jobflow`, `set_termination_protection`, etc.
- Tested E2E w/ example pipeline via Jenkins and Emrfile bootstrap process: https://console.aws.amazon.com/elasticmapreduce/home?region=us-east-1#cluster-details:j-1SOAGFLB8G2TB
- Updated a few unit tests, before realizing very few of the tests pass in master anyways

JIRA: https://foursquare.atlassian.net/browse/APL-2001
Design: https://foursquare.atlassian.net/wiki/spaces/ADS/pages/808321820/APL-2001+Support+Temporary+Role+Credentials+in+Elmer

@sewichi/platform 