### PR TITLE
Adjust AWS-SDK gem dependency to allow v3

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '~> 1.7.1')
   s.add_dependency('fog', '~> 1.25.0')
   s.add_dependency('fog-core', '~> 1.25.0')
-  s.add_dependency('aws-sdk-core', '~> 2.0')
+  s.add_dependency('aws-sdk', '>= 2')
 
   s.add_development_dependency('rake', '~> 10.1.0')
   s.add_development_dependency('rspec', '~> 2.12.0')

--- a/lib/elasticity.rb
+++ b/lib/elasticity.rb
@@ -2,7 +2,7 @@ require 'base64'
 require 'set'
 require 'time'
 
-require 'aws-sdk-core'
+require 'aws-sdk'
 require 'rest_client'
 require 'nokogiri'
 require 'fog'

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.10.0'
+  VERSION = '2.10.1'
 end


### PR DESCRIPTION
We are upgrading data-pipelines to AWS-SDK v3, and in order to support
that upgrade we need to change this gem’s gemspec to allow running against
AWS-SDK v3.

Jira link: https://foursquare.atlassian.net/browse/APL-2039