### PR TITLE
Lock dry inflector

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '~> 1.7.1')
   s.add_dependency('fog', '~> 1.25.0')
   s.add_dependency('fog-core', '~> 1.25.0')
+  s.add_dependency('dry-inflector', '= 0.2.0')
   s.add_dependency('aws-sdk', '>= 2')
 
   s.add_development_dependency('rake', '~> 10.1.0')

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '2.10.1'
+  VERSION = '2.10.2'
 end


### PR DESCRIPTION
At roughly 12:00 AM PST a new version of dry-inflector 0.2.1 was pushed out. This version of the gem has a dependency on ruby >= 2.6. We rely on fog which depends on fog-brightbox which has a loose dependency on dry-inflector that allowed us to try and install the new version. This is the stacktace I found during debugging issues in jenkins trying to install our gems. I locally bundled a new version with the code in this PR and pushed it to our gem server. Builds are now succeeding.

@sewichi/platform 


```
02:07:01 Installing dry-inflector 0.2.1
02:07:01 Gem::RuntimeRequirementNotMetError: dry-inflector requires Ruby version >=
02:07:01 2.6.0. The current ruby version is 2.4.0.
02:07:01 An error occurred while installing dry-inflector (0.2.1), and Bundler cannot
02:07:01 continue.
02:07:01 Make sure that `gem install dry-inflector -v '0.2.1' --source
02:07:01 'https://*@gems-cdn.placed.com/geminabox/'` succeeds before
02:07:01 bundling.
02:07:01 
02:07:01 In Gemfile:
02:07:01   attribution-jobs was resolved to 2.206.2, which depends on
02:07:01     analytics-jobs was resolved to 2.206.0, which depends on
02:07:01       userprofile-jobs was resolved to 2.206.0, which depends on
02:07:01         data-collection-jobs was resolved to 2.206.0, which depends on
02:07:01           inference-jobs was resolved to 2.206.1, which depends on
02:07:01             emr-job was resolved to 2.206.0, which depends on
02:07:01               placed-elasticity was resolved to 2.10.1, which depends on
02:07:01                 fog was resolved to 1.25.0, which depends on
02:07:01                   fog-brightbox was resolved to 0.16.1, which depends on
02:07:01                     dry-inflector
02:07:01 Command Fail..
```